### PR TITLE
Update shards and get things working on Crystal 1.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is an ORM comparrison test for crystal. This test will compare a few differ
 ## Subjects
 
 1. [Avram](https://github.com/luckyframework/avram) (currently disabled since it conflicts with Granite)
-1. [Clear](https://github.com/anykeyh/clear)  (currently disabled until support for db 0.10)
+1. [Clear](https://github.com/anykeyh/clear)
 1. [Crecto](https://github.com/Crecto/crecto)
 1. [Granite](https://github.com/amberframework/granite)
 1. [Jennifer](https://github.com/imdrasil/jennifer.cr)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is an ORM comparrison test for crystal. This test will compare a few differ
 
 ## Subjects
 
-1. [Avram](https://github.com/luckyframework/avram)
+1. [Avram](https://github.com/luckyframework/avram) (currently disabled since it conflicts with Granite)
 1. [Clear](https://github.com/anykeyh/clear)  (currently disabled until support for db 0.10)
 1. [Crecto](https://github.com/Crecto/crecto)
 1. [Granite](https://github.com/amberframework/granite)

--- a/shard.lock
+++ b/shard.lock
@@ -14,8 +14,8 @@ shards:
     version: 0.1.0+git.commit.46c4c14594057dbcfaf27e7e7c8c164d3f0ce3f1
 
   clear:
-    git: https://github.com/anykeyh/clear.git
-    version: 0.9+git.commit.480289555c833793fa6964398fefec6b7e25168d
+    git: https://github.com/lbguilherme/clear.git
+    version: 0.9+git.commit.e4b6aced68ce80f61cbb6fd95cd3917b7e551ac0
 
   crecto:
     git: https://github.com/crecto/crecto.git

--- a/shard.lock
+++ b/shard.lock
@@ -3,67 +3,67 @@ version: 2.0
 shards:
   admiral:
     git: https://github.com/jwaldrip/admiral.cr.git
-    version: 1.11.2+git.commit.c3c3467953654554b72c24e7b853d6fbb23f10c0
+    version: 1.12.1
 
   avram:
     git: https://github.com/luckyframework/avram.git
-    version: 0.17.0+git.commit.419cca8d25512be45766d3224e5c56deb2ce5bd2
+    version: 0.22.0+git.commit.9251a965372d319977558bcbe3d0696f60aeb45e
 
-  blank:
-    git: https://github.com/kostya/blank.git
-    version: 0.1.0
+  cadmium_transliterator:
+    git: https://github.com/cadmiumcr/transliterator.git
+    version: 0.1.0+git.commit.46c4c14594057dbcfaf27e7e7c8c164d3f0ce3f1
 
   clear:
     git: https://github.com/anykeyh/clear.git
-    version: 0.8+git.commit.4120e5e9bdea4d1ea78c9c7c74b6deb65bfcebe2
+    version: 0.9+git.commit.480289555c833793fa6964398fefec6b7e25168d
 
   crecto:
-    git: https://github.com/Crecto/crecto.git
-    version: 0.11.2+git.commit.fd65545083be0200aac4430d7673f74a2a08f7f8
+    git: https://github.com/crecto/crecto.git
+    version: 0.12.1+git.commit.b645ea55414bbf8f7ee6bd91c3298fd0ed50a26c
 
   db: # Overridden
     git: https://github.com/crystal-lang/crystal-db.git
-    version: 0.10.0+git.commit.bd456028644853f852f5adfe053142e6ad885e52
+    version: 0.13.1+git.commit.532ae075bd810cfd0032b74189ec01fcfba2f355
 
   dexter:
     git: https://github.com/luckyframework/dexter.git
-    version: 0.3.1
-
-  future:
-    git: https://github.com/crystal-community/future.cr.git
-    version: 0.1.0
+    version: 0.3.4
 
   generate:
     git: https://github.com/anykeyh/generate.cr.git
-    version: 0.1.0+git.commit.27a59d663ded8ce39a361e3a88b8dd747f59ce42
+    version: 0.1.0+git.commit.f5dafc934a70e0ee2f246dddf3df44686f844da2
 
   granite:
     git: https://github.com/amberframework/granite.git
-    version: 0.21.1+git.commit.c1e28172bb7ff59490da21839d80bd0e7b5681df
+    version: 0.23.2+git.commit.c8b80ee31ea86b130028ecdbd86b18d16c41780d
 
   habitat:
     git: https://github.com/luckyframework/habitat.git
-    version: 0.4.4
+    version: 0.4.8
 
   i18n:
-    git: https://github.com/TechMagister/i18n.cr.git
-    version: 0.3.1
+    git: https://github.com/crimson-knight/i18n.cr.git
+    version: 0.4.1
 
   ifrit:
     git: https://github.com/imdrasil/ifrit.git
-    version: 0.1.2
+    version: 0.1.3
 
   inflector:
-    git: https://github.com/phoffer/inflector.cr.git
-    version: 0.1.8
+    git: https://github.com/anykeyh/inflector.cr.git
+    version: 0.1.8+git.commit.dc5c898b0a834617d8b3ff73ac5a2239bd9fc019
 
   jennifer:
     git: https://github.com/imdrasil/jennifer.cr.git
-    version: 0.9.0+git.commit.22bbaa466856594ef601589faae25320c8aa3f20
+    version: 0.13.0+git.commit.0f4e4bd58112dafc92ca0d76814001a66a50d745
 
-  lucky_cli:
-    git: https://github.com/luckyframework/lucky_cli.git
-    version: 0.24.0
+  lucky_cache:
+    git: https://github.com/luckyframework/lucky_cache.git
+    version: 0.1.1
+
+  lucky_task:
+    git: https://github.com/luckyframework/lucky_task.git
+    version: 0.1.1
 
   onyx-sql:
     git: https://github.com/onyxframework/sql.git
@@ -71,19 +71,19 @@ shards:
 
   pg: # Overridden
     git: https://github.com/will/crystal-pg.git
-    version: 0.22.1+git.commit.cafeaf6127d8d50cfc345ae987f63e8d39fd9041
+    version: 0.28.0+git.commit.c83388df5ce90754032b157b1cd90b6ce69c0e7e
 
   pulsar:
     git: https://github.com/luckyframework/pulsar.git
-    version: 0.2.1
+    version: 0.2.3
 
   shell-table:
     git: https://github.com/luckyframework/shell-table.cr.git
-    version: 0.9.2+git.commit.078a04ea58ead5203bb435a3b5fff448ddabaeea
+    version: 0.9.3
 
-  teeplate:
-    git: https://github.com/luckyframework/teeplate.git
-    version: 0.8.2
+  splay_tree_map:
+    git: https://github.com/wyhaines/splay_tree_map.cr.git
+    version: 0.2.2
 
   time_format:
     git: https://github.com/vladfaust/time_format.cr.git
@@ -91,5 +91,5 @@ shards:
 
   wordsmith:
     git: https://github.com/luckyframework/wordsmith.git
-    version: 0.2.1
+    version: 0.3.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.1.0
 authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>
 
-crystal: 0.35.1
+crystal: 1.22.2
 
 license: MIT
 

--- a/shard.yml
+++ b/shard.yml
@@ -22,8 +22,9 @@ dependencies:
     branch: master
 
   clear:
-    github: anykeyh/clear
-    branch: master
+    # https://github.com/anykeyh/clear/pull/225
+    github: lbguilherme/clear
+    branch: patch-1
 
   avram:
     github: luckyframework/avram

--- a/src/orm_test.cr
+++ b/src/orm_test.cr
@@ -4,13 +4,20 @@ require "./orm_test/*"
 DATABASE = {host: "localhost", name: "crystal_orm_test", user: "postgres"}
 
 # Enable all once updated
-# ["Avram", "Clear", "Crecto", "Granite", "Jennifer", "OnyxSql"]
+ENABLED_ORMS = [
+  "Avram",
+  # "Clear",
+  "Crecto",
+  "Granite",
+  "Jennifer",
+  # "OnyxSql",
+]
 
 {% for test in ["simple_insert", "simple_select", "simple_update", "simple_delete"] %}
 
   puts "BENCHMARKING {{test.id}}"
   Benchmark.bm do |x|
-    {% for subject in ["Avram", "Crecto", "Granite", "Jennifer"] %}
+    {% for subject in ENABLED_ORMS %}
       x.report("{{subject.id}} {{test.id}}") do
         1000.times do |i|
           OrmTest{{subject.id}}.{{test.id}}(i)

--- a/src/orm_test.cr
+++ b/src/orm_test.cr
@@ -6,7 +6,7 @@ DATABASE = {host: "localhost", name: "crystal_orm_test", user: "postgres"}
 # Enable all once updated
 ENABLED_ORMS = [
   # "Avram",
-  # "Clear",
+  "Clear",
   "Crecto",
   "Granite",
   "Jennifer",

--- a/src/orm_test.cr
+++ b/src/orm_test.cr
@@ -5,7 +5,7 @@ DATABASE = {host: "localhost", name: "crystal_orm_test", user: "postgres"}
 
 # Enable all once updated
 ENABLED_ORMS = [
-  "Avram",
+  # "Avram",
   # "Clear",
   "Crecto",
   "Granite",

--- a/src/orm_test/avram.cr
+++ b/src/orm_test/avram.cr
@@ -1,3 +1,3 @@
 require "pg"
-require "avram"
-require "./avram/setup"
+# require "avram"
+# require "./avram/setup"

--- a/src/orm_test/clear.cr
+++ b/src/orm_test/clear.cr
@@ -1,4 +1,3 @@
 require "pg"
-# https://github.com/anykeyh/clear/pull/190
-#require "clear"
-#require "./clear/setup"
+require "clear"
+require "./clear/setup"

--- a/src/orm_test/clear/setup.cr
+++ b/src/orm_test/clear/setup.cr
@@ -7,12 +7,12 @@ module OrmTestClear
     include Clear::Model
     self.table = "users"
 
-    column id : Int64, primary: true
+    column id : Int64, primary: true, presence: false
     column name : String
     column orm : String
     column idx : Int32
-    column created_at : Time
-    column updated_at : Time
+    column created_at : Time, presence: false
+    column updated_at : Time, presence: false
   end
 
   # INSERT INTO users(name) VALUES(whatever)

--- a/src/orm_test/onyx_sql.cr
+++ b/src/orm_test/onyx_sql.cr
@@ -1,3 +1,3 @@
 require "pg"
-require "onyx-sql"
-require "./onyx_sql/setup"
+# require "onyx-sql"
+# require "./onyx_sql/setup"


### PR DESCRIPTION
Thanks for putting this together! I was about to do something similar (due to needing to move away from Clear, and wanting to review the options), but I can build on this instead.

This PR just updates all shards and gets things working on Crystal 1.12.2 (Crystal 1.13.x will need some more changes; in particular Clear does not currently compile).

I think this is all pretty non-controversial, except perhaps for the disabling of Avram! You're probably in a good position to comment on whether / how this can be used alongside Granite without conflicting 😄 To see the issue, just uncomment the avram require.